### PR TITLE
Updates to use HUGGING FACE instead of in-memory sentence transformer model

### DIFF
--- a/ai-service/.env.example
+++ b/ai-service/.env.example
@@ -13,6 +13,10 @@ MASTER_KEY=change-this-to-a-long-random-secret
 # Model name from HuggingFace. First run downloads ~90MB to ~/.cache/torch/sentence_transformers/
 MODEL_NAME=all-MiniLM-L6-v2
 
+# ─── Embeddings (HuggingFace Serverless Inference API) ────────────────────────
+# Uses sentence-transformers/all-MiniLM-L6-v2 via remote API (no local PyTorch).
+HUGGINGFACE_API_KEY=hf_your_token_here
+
 # ─── Redis (optional) ─────────────────────────────────────────────────────────
 # Leave empty to disable caching (service works, just no caching)
 REDIS_URL=redis://localhost:6379

--- a/ai-service/app/config.py
+++ b/ai-service/app/config.py
@@ -12,7 +12,14 @@ class Settings(BaseSettings):
     MASTER_KEY: str                    # Shared secret for master JWT
 
     # Embedding model (all-MiniLM-L6-v2 — stays unchanged)
-    MODEL_NAME: str = "all-MiniLM-L6-v2"
+    # MODEL_NAME: str = "all-MiniLM-L6-v2"
+
+    # ─── HuggingFace Serverless Inference API (Embeddings) ────────────────────
+    # Free API for sentence-transformers/all-MiniLM-L6-v2 (384 dims, no local model)
+    HUGGINGFACE_API_KEY: str = ""
+
+    # Shown in /health endpoint
+    MODEL_NAME: str = "sentence-transformers/all-MiniLM-L6-v2 (HF API)"
 
     # Redis (optional — cache is disabled if REDIS_URL is not set)
     REDIS_URL: str = ""

--- a/ai-service/app/embeddings(old).py
+++ b/ai-service/app/embeddings(old).py
@@ -1,0 +1,89 @@
+"""
+embeddings.py — SentenceTransformer model singleton.
+
+Model: all-MiniLM-L6-v2
+  - 384 dimensions
+  - ~90MB download (cached after first run)
+  - CPU-friendly, fast inference
+  - Produces normalised vectors (cosine similarity = dot product)
+"""
+
+from functools import lru_cache
+from typing import Union
+from sentence_transformers import SentenceTransformer
+
+from app.config import settings
+import numpy as np
+
+_model: SentenceTransformer | None = None
+
+
+def load_model() -> None:
+    """Pre-load the model on startup (avoids cold-start on first request)."""
+    global _model
+    print(f"🤖 Loading embedding model: {settings.MODEL_NAME}...")
+    _model = SentenceTransformer(settings.MODEL_NAME)
+    print(f"   ✅ Model loaded — {_model.get_sentence_embedding_dimension()} dimensions")
+
+
+def get_model() -> SentenceTransformer:
+    if _model is None:
+        raise RuntimeError("Model not loaded — call load_model() first")
+    return _model
+
+
+def encode(text: Union[str, list[str]]) -> list[float] | list[list[float]]:
+    """
+    Encode text(s) into normalised embedding vector(s).
+
+    Single string  → list[float]  (length 384)
+    List of strings → list[list[float]]
+    """
+    model = get_model()
+    result = model.encode(text, normalize_embeddings=True)
+    if isinstance(text, str):
+        return result.tolist()
+    return [r.tolist() for r in result]
+
+
+def weighted_average_embeddings(
+    embeddings: list[list[float]],
+    weights: list[float],
+) -> list[float]:
+    """
+    Compute a weighted average of multiple normalised embedding vectors.
+    Returns a normalised result vector.
+    Used to build a user's 'taste profile' from their history.
+    """
+
+    if not embeddings:
+        raise ValueError("No embeddings to average")
+
+    emb_matrix = np.array(embeddings, dtype=float)     # shape (N, 384)
+    w = np.array(weights, dtype=float)
+    w = w / w.sum()                                     # normalise weights to sum=1
+    result = (emb_matrix * w[:, np.newaxis]).sum(axis=0)
+
+    # Re-normalise to unit vector
+    norm = np.linalg.norm(result)
+    if norm > 0:
+        result /= norm
+
+    return result.tolist()
+
+
+def build_user_profile(history: list[dict]) -> list[float] | None:
+    """
+    Build a user's taste-profile vector from their event history.
+    Returns None if no embeddings are available.
+
+    history: list of dicts with keys: embedding (list[float]), weight (float)
+    """
+    valid = [row for row in history if row.get("embedding") is not None]
+    if not valid:
+        return None
+
+    embeddings = [row["embedding"] for row in valid]
+    weights    = [float(row.get("weight", 0.5)) for row in valid]
+
+    return weighted_average_embeddings(embeddings, weights)

--- a/ai-service/app/embeddings.py
+++ b/ai-service/app/embeddings.py
@@ -1,50 +1,114 @@
 """
-embeddings.py — SentenceTransformer model singleton.
+embeddings.py — HuggingFace Serverless Inference API client.
 
-Model: all-MiniLM-L6-v2
-  - 384 dimensions
-  - ~90MB download (cached after first run)
-  - CPU-friendly, fast inference
+Replaces the local SentenceTransformer / PyTorch backend with a remote HTTP
+call to the free HuggingFace Inference API.
+
+Model: sentence-transformers/all-MiniLM-L6-v2
+  - 384 dimensions (unchanged — no schema migration needed)
   - Produces normalised vectors (cosine similarity = dot product)
+  - Free via HuggingFace Serverless Inference API (HUGGINGFACE_API_KEY)
+
+Public API is identical to the previous local implementation:
+  load_model()                         — no-op (kept for startup compatibility)
+  encode(text)                         — list[float] | list[list[float]]
+  weighted_average_embeddings(...)     — list[float]
+  build_user_profile(history)          — list[float] | None
 """
 
-from functools import lru_cache
 from typing import Union
-from sentence_transformers import SentenceTransformer
-
-from app.config import settings
+import logging
+import httpx
 import numpy as np
 
-_model: SentenceTransformer | None = None
+from app.config import settings
 
+logger = logging.getLogger(__name__)
+
+# ─── Constants ────────────────────────────────────────────────────────────────
+
+_HF_API_URL = (
+    "https://router.huggingface.co/hf-inference/models/"
+    "sentence-transformers/all-MiniLM-L6-v2/pipeline/feature-extraction"
+)
+_EXPECTED_DIM = 384
+# httpx timeout: connect=5s, read=30s (HF cold-starts can be slow)
+_TIMEOUT = httpx.Timeout(connect=5.0, read=30.0, write=10.0, pool=5.0)
+
+
+# ─── Startup hook (no-op — kept for main.py compatibility) ────────────────────
 
 def load_model() -> None:
-    """Pre-load the model on startup (avoids cold-start on first request)."""
-    global _model
-    print(f"🤖 Loading embedding model: {settings.MODEL_NAME}...")
-    _model = SentenceTransformer(settings.MODEL_NAME)
-    print(f"   ✅ Model loaded — {_model.get_sentence_embedding_dimension()} dimensions")
+    """
+    No-op. Kept so main.py lifespan startup code does not need changes.
+    Validates that HUGGINGFACE_API_KEY is configured and logs readiness.
+    """
+    if not settings.HUGGINGFACE_API_KEY:
+        logger.warning(
+            "⚠️  HUGGINGFACE_API_KEY is not set. "
+            "Embedding calls will fail with 401 Unauthorized."
+        )
+    else:
+        logger.info(
+            "🤖 Embeddings backend: HuggingFace Inference API "
+            "(sentence-transformers/all-MiniLM-L6-v2, %d dims)",
+            _EXPECTED_DIM,
+        )
 
 
-def get_model() -> SentenceTransformer:
-    if _model is None:
-        raise RuntimeError("Model not loaded — call load_model() first")
-    return _model
-
+# ─── Core encode function ─────────────────────────────────────────────────────
 
 def encode(text: Union[str, list[str]]) -> list[float] | list[list[float]]:
     """
-    Encode text(s) into normalised embedding vector(s).
+    Encode text(s) into normalised 384-dimensional embedding vector(s)
+    via the HuggingFace Serverless Inference API (synchronous).
 
-    Single string  → list[float]  (length 384)
+    Single string  → list[float]         (length 384)
     List of strings → list[list[float]]
     """
-    model = get_model()
-    result = model.encode(text, normalize_embeddings=True)
-    if isinstance(text, str):
-        return result.tolist()
-    return [r.tolist() for r in result]
+    is_single = isinstance(text, str)
+    inputs = [text] if is_single else text
 
+    headers = {
+        "Authorization": f"Bearer {settings.HUGGINGFACE_API_KEY}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "inputs": inputs,
+        # Ask HF to return normalised vectors so cosine sim = dot product
+        "options": {"normalize_embeddings": True, "wait_for_model": True},
+    }
+
+    try:
+        with httpx.Client(timeout=_TIMEOUT) as client:
+            response = client.post(_HF_API_URL, json=payload, headers=headers)
+            response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        logger.error(
+            "HuggingFace API returned %s: %s",
+            exc.response.status_code,
+            exc.response.text[:200],
+        )
+        raise RuntimeError(
+            f"Embedding API error {exc.response.status_code}: {exc.response.text[:200]}"
+        ) from exc
+    except httpx.RequestError as exc:
+        logger.error("HuggingFace API request failed: %s", exc)
+        raise RuntimeError(f"Embedding API unreachable: {exc}") from exc
+
+    result: list[list[float]] = response.json()
+
+    # Guard: validate returned shape matches expected dimensions
+    if not result or len(result[0]) != _EXPECTED_DIM:
+        raise RuntimeError(
+            f"Unexpected embedding dimension from API: "
+            f"got {len(result[0]) if result else 0}, expected {_EXPECTED_DIM}"
+        )
+
+    return result[0] if is_single else result
+
+
+# ─── Profile builder helpers (unchanged logic, same public API) ───────────────
 
 def weighted_average_embeddings(
     embeddings: list[list[float]],
@@ -52,19 +116,17 @@ def weighted_average_embeddings(
 ) -> list[float]:
     """
     Compute a weighted average of multiple normalised embedding vectors.
-    Returns a normalised result vector.
-    Used to build a user's 'taste profile' from their history.
+    Returns a re-normalised result vector (unit length).
+    Used to build a user's 'taste profile' from their event history.
     """
-
     if not embeddings:
         raise ValueError("No embeddings to average")
 
-    emb_matrix = np.array(embeddings, dtype=float)     # shape (N, 384)
+    emb_matrix = np.array(embeddings, dtype=float)   # shape (N, 384)
     w = np.array(weights, dtype=float)
-    w = w / w.sum()                                     # normalise weights to sum=1
+    w = w / w.sum()                                    # normalise weights → sum=1
     result = (emb_matrix * w[:, np.newaxis]).sum(axis=0)
 
-    # Re-normalise to unit vector
     norm = np.linalg.norm(result)
     if norm > 0:
         result /= norm
@@ -74,10 +136,12 @@ def weighted_average_embeddings(
 
 def build_user_profile(history: list[dict]) -> list[float] | None:
     """
-    Build a user's taste-profile vector from their event history.
-    Returns None if no embeddings are available.
+    Build a user's taste-profile vector from their event engagement history.
+    Returns None if no pre-computed embeddings are available in the history rows.
 
-    history: list of dicts with keys: embedding (list[float]), weight (float)
+    history: list of dicts with keys:
+        embedding (list[float])  — pre-stored vector from the DB
+        weight    (float)        — engagement weight (e.g. 0.5–1.0)
     """
     valid = [row for row in history if row.get("embedding") is not None]
     if not valid:

--- a/ai-service/requirements.txt
+++ b/ai-service/requirements.txt
@@ -10,7 +10,9 @@ asyncpg==0.29.0
 pgvector==0.3.2
 
 # ML / Embeddings
-sentence-transformers==3.0.1
+# sentence-transformers==3.0.1
+
+# Numpy
 numpy==2.4.6
 
 # Auth
@@ -30,7 +32,7 @@ httpx==0.27.0
 openai==1.35.0
 
 # RAG pipeline utilities
-langchain-core==0.2.0
+# langchain-core==0.2.0
 
 # Token counting for safe prompt construction
 tiktoken==0.7.0


### PR DESCRIPTION
## Description

* [refactor(ai-service): optimize dependencies by removing sentence-transformers and langchain-core](https://github.com/AnirudhAP2k/CorpConnect/commit/e67d4c82c1c7548097663fc45c3728a4c9f6aa04) 

* [feat(ai-service): integrate HuggingFace Serverless Inference API for embeddings](https://github.com/AnirudhAP2k/CorpConnect/commit/e8f006ac18bca205d919a66ce8f25ed39dccdb8e) 

* [refactor(ai-service): preserve local sentence-transformers embedding implementation as backup](https://github.com/AnirudhAP2k/CorpConnect/commit/de3d322a82dd2c948d912f49616a36cfcc93de53) 

* [refactor(ai-service): update settings with HUGGINGFACE_API_KEY configuration](https://github.com/AnirudhAP2k/CorpConnect/commit/e592384ea78f4c397be4801cc066a46708400d04) 

* [docs(ai-service): add HUGGINGFACE_API_KEY to environment example](https://github.com/AnirudhAP2k/CorpConnect/commit/53de1c301be47c85abf02947319e3f3cabb32e6d)